### PR TITLE
Fix readme to pass name to `addMatchImageSnapshotCommand`

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ For example, the default options we use in `<rootDir>/cypress/support/commands.j
 ```js
 import kebabCase from 'lodash/kebabcase';
 
-addMatchImageSnapshotCommand({
+addMatchImageSnapshotCommand('matchImageSnapshot', {
   failureThreshold: 0.03, // threshold for entire image
   failureThresholdType: 'percent', // percent of image or number of pixels
   customDiffConfig: { threshold: 0.1 }, // threshold for each pixel


### PR DESCRIPTION
Thanks for this project!

Without passing the name (after also checking the source) the command won't register and tests will fail.