### PR TITLE
Handle options passed to addMatchImageSnapshotCommand

### DIFF
--- a/__tests__/command.test.js
+++ b/__tests__/command.test.js
@@ -7,9 +7,15 @@
 
 global.Cypress = {
   config: () => 'cheese',
+  Commands: {
+    add: jest.fn(),
+  },
 };
 
-const { matchImageSnapshotCommand } = require('../src/command');
+const {
+  matchImageSnapshotCommand,
+  addMatchImageSnapshotCommand,
+} = require('../src/command');
 
 const defaultOptions = {
   failureThreshold: 0,
@@ -71,5 +77,35 @@ describe('command', () => {
     expect(
       boundMatchImageSnapshot(subject, commandOptions)
     ).rejects.toThrowErrorMatchingSnapshot();
+  });
+
+  it('should add command', () => {
+    Cypress.Commands.add.mockReset();
+    addMatchImageSnapshotCommand();
+    expect(Cypress.Commands.add).toHaveBeenCalledWith(
+      'matchImageSnapshot',
+      expect.any(Function),
+      { prevSubject: 'optional' }
+    );
+  });
+
+  it('should add command with custom name', () => {
+    Cypress.Commands.add.mockReset();
+    addMatchImageSnapshotCommand('sayCheese');
+    expect(Cypress.Commands.add).toHaveBeenCalledWith(
+      'sayCheese',
+      expect.any(Function),
+      { prevSubject: 'optional' }
+    );
+  });
+
+  it('should add command with options', () => {
+    Cypress.Commands.add.mockReset();
+    addMatchImageSnapshotCommand({ failureThreshold: 0.1 });
+    expect(Cypress.Commands.add).toHaveBeenCalledWith(
+      'matchImageSnapshot',
+      expect.any(Function),
+      { prevSubject: 'optional' }
+    );
   });
 });

--- a/src/command.js
+++ b/src/command.js
@@ -51,11 +51,12 @@ export function matchImageSnapshotCommand(defaultOptions) {
 }
 
 export function addMatchImageSnapshotCommand(
-  name = 'matchImageSnapshot',
-  options
+  maybeName = 'matchImageSnapshot',
+  maybeOptions
 ) {
-  const defaultOptions = typeof name === 'string' ? options : name;
-  Cypress.Commands.add(name, matchImageSnapshotCommand(defaultOptions), {
+  const options = typeof maybeName === 'string' ? maybeOptions : maybeName;
+  const name = typeof maybeName === 'string' ? maybeName : 'matchImageSnapshot';
+  Cypress.Commands.add(name, matchImageSnapshotCommand(options), {
     prevSubject: 'optional',
   });
 }


### PR DESCRIPTION
Now all variations of `addMatchImageSnapshotCommand` work:
```
addMatchImageSnapshotCommand();
addMatchImageSnapshotCommand('sayCheese');
addMatchImageSnapshotCommand(options);
addMatchImageSnapshotCommand('sayCheese', options);
```