### PR TITLE
Move updateSnapshots flag to env

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,4 +110,4 @@ The workflow of `cy.matchImageSnapshot()` when running Cypress is:
 1.  Take a screenshot with `cy.screenshot()` named according to the current test.
 2.  Check if a saved snapshot exists in `<rootDir>/cypress/snapshots` and if so diff against that snapshot.
 3.  If there is a resulting diff, save it to `<rootDir>/cypress/snapshots/__diff_output__`.
-4.  If the diff is intended, run Cypress again with `--config updateSnapshots=true` to update the snapshots.
+4.  If the diff is intended, run Cypress again with `--env updateSnapshots=true` to update the snapshots.

--- a/__tests__/command.test.js
+++ b/__tests__/command.test.js
@@ -7,6 +7,7 @@
 
 global.Cypress = {
   config: () => 'cheese',
+  env: () => false,
   Commands: {
     add: jest.fn(),
   },
@@ -42,7 +43,7 @@ describe('command', () => {
     expect(cy.task).toHaveBeenCalledWith('Matching image snapshot', {
       screenshotsFolder: 'cheese',
       fileServerFolder: 'cheese',
-      updateSnapshots: 'cheese',
+      updateSnapshots: false,
       options: {
         failureThreshold: 10,
         failureThresholdType: 'pixel',

--- a/src/command.js
+++ b/src/command.js
@@ -9,7 +9,7 @@ import kebabCase from 'lodash.kebabcase';
 
 const screenshotsFolder = Cypress.config('screenshotsFolder');
 const fileServerFolder = Cypress.config('fileServerFolder');
-const updateSnapshots = Cypress.config('updateSnapshots') || false;
+const updateSnapshots = Cypress.env('updateSnapshots') || false;
 
 const defaultFileNameTransform = (name = '', test) =>
   kebabCase(`${test.title}-${name}`);


### PR DESCRIPTION
I think adding `updateSnapshots` to `config` was working due to a bug in Cypress, moving the flag to `env` which is intended for dynamic variables.