### PR TITLE
Add support for custom snapshots dir.

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -48,7 +48,11 @@ export function matchImageSnapshotPlugin({ path: screenshotPath }) {
   );
   const screenshotDir = screenshotPath.replace(screenshotFileName, '');
   const snapshotIdentifier = screenshotFileName.replace('.png', '');
-  const snapshotsDir = screenshotDir.replace('screenshots', 'snapshots');
+  let snapshotsDir = screenshotDir.replace('screenshots', 'snapshots');
+
+  if(options.customSnapshotsDir) {
+    snapshotsDir = options.customSnapshotsDir + screenshotDir.split('screenshots')[1]
+  }
 
   const snapshotKebabPath = path.join(
     snapshotsDir,
@@ -59,7 +63,7 @@ export function matchImageSnapshotPlugin({ path: screenshotPath }) {
     `${snapshotIdentifier}${dotSnap}`
   );
 
-  const diffDir = path.join(snapshotsDir, '__diff_output__');
+  const diffDir = path.join((options.customSnapshotsDir) ? screenshotDir : snapshotsDir, '__diff_output__');
   const diffDotPath = path.join(diffDir, `${snapshotIdentifier}${dotDiff}`);
 
   if (fs.pathExistsSync(snapshotDotPath)) {
@@ -77,14 +81,20 @@ export function matchImageSnapshotPlugin({ path: screenshotPath }) {
   });
 
   const { pass, added, updated, diffOutputPath } = snapshotResults;
-
+  
   if (!pass && !added && !updated) {
     fs.copySync(diffOutputPath, diffDotPath);
     fs.removeSync(diffOutputPath);
     fs.removeSync(snapshotKebabPath);
 
+
+    if(options.customSnapshotsDir) {
+      snapshotResults.diffOutputPath = diffDotPath;
+      fs.removeSync(diffOutputPath.substring(0, diffOutputPath.lastIndexOf('__diff_output__') + '__diff_output__'.length));
+    }
+
     return {
-      path: diffOutputPath,
+      path: diffDotPath,
     };
   }
 


### PR DESCRIPTION
Hi,

When using your plugin we found that it is currently not possible to change the snapshot directory that is being used. We would like to keep the output during run and the actual snapshot separate.

From our perspective the code changes that were needed to make this change feel a bit dirty/hacky. We would like to improve this but that would likely result in the new version not to be backwards compatible.

**Proposal:**
Make all directories and filenames configurable through the Cypress config. The default output should be the same as the current design.

Currently the plugin does not accept the config object from Cypress, to be able to support the above we need to add this, so this is what would make the change not backwards incompatible.

Please let us know what you think.