### PR TITLE
Add customSnapshotsDir option

### DIFF
--- a/__tests__/plugin.test.js
+++ b/__tests__/plugin.test.js
@@ -25,21 +25,28 @@ jest.mock('fs-extra', () => ({
 
 describe('plugin', () => {
   it('should pass options through', () => {
+    const originalCwd = process.cwd;
+    process.cwd = () => '';
+
     const options = {
       updateSnapshots: true,
     };
 
     matchImageSnapshotOptions(options);
 
-    const result = matchImageSnapshotPlugin({ path: '/path/to/cheese' });
+    const result = matchImageSnapshotPlugin({
+      path: '/screenshots/path/to/cheese',
+    });
     expect(result).toEqual({ path: '/path/to/diff' });
     expect(diffImageToSnapshot).toHaveBeenCalledWith({
-      snapshotsDir: '/path/to/',
+      snapshotsDir: '/cypress/snapshots/path/to/',
       updateSnapshot: true,
       receivedImageBuffer: 'cheese',
       snapshotIdentifier: 'cheese',
       failureThreshold: 0,
       failureThresholdType: 'pixel',
     });
+
+    process.cwd = originalCwd;
   });
 });

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -5,10 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import path from 'path';
 import fs from 'fs-extra';
 import { diffImageToSnapshot } from 'jest-image-snapshot/src/diff-snapshot';
-
-const path = require('path');
 
 let snapshotOptions = {};
 let snapshotResults = {};
@@ -38,6 +37,7 @@ export function matchImageSnapshotPlugin({ path: screenshotPath }) {
     options: {
       failureThreshold = 0,
       failureThresholdType = 'pixel',
+      customSnapshotsDir = '/cypress/snapshots',
       ...options
     } = {},
   } = snapshotOptions;
@@ -48,7 +48,11 @@ export function matchImageSnapshotPlugin({ path: screenshotPath }) {
   );
   const screenshotDir = screenshotPath.replace(screenshotFileName, '');
   const snapshotIdentifier = screenshotFileName.replace('.png', '');
-  const snapshotsDir = screenshotDir.replace('screenshots', 'snapshots');
+  const snapshotsDir = path.join(
+    process.cwd(),
+    customSnapshotsDir,
+    /screenshots(.*)/.exec(screenshotDir)[1]
+  );
 
   const snapshotKebabPath = path.join(
     snapshotsDir,


### PR DESCRIPTION
Adds `customSnapshotsDir` as an option to `addMatchImageSnapshot` so that a custom snapshot directory can be specified as requested in #23.