### PR TITLE
Exports the correct diff dot path.

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -88,7 +88,7 @@ export function matchImageSnapshotPlugin({ path: screenshotPath }) {
     fs.removeSync(snapshotKebabPath);
 
     return {
-      path: diffOutputPath,
+      path: diffDotPath,
     };
   }
 


### PR DESCRIPTION
Currently the `diffOutputPath` prevents cypress from uploading the __diff_output__ screenshot as it tries to upload `example-diff.png` instead of `example.diff.png`