### PR TITLE
Add option for custom image diff directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,10 @@ describe('Login', () => {
 
 ## Options
 
-Any options for [`cy.screenshot()`](https://docs.cypress.io/api/commands/screenshot.html#Arguments) and [jest-image-snapshot](https://github.com/americanexpress/jest-image-snapshot#optional-configuration) can be passed in the `options` argument to `addMatchImageSnapshotCommand` and `cy.matchImageSnapshot()`. The local options in `cy.matchImageSnapshot()` will overwrite the default options set in `addMatchImageSnapshot`.
+- `customSnapshotsDir` : Path to the directory that snapshot images will be written to, defaults to `<rootDir>/cypress/snapshots`.
+- `customDiffDir`: Path to the directory that diff images will be written to, defaults to a sibling `__diff_output__` directory alongside each snapshot.
+
+Additionally, any options for [`cy.screenshot()`](https://docs.cypress.io/api/commands/screenshot.html#Arguments) and [jest-image-snapshot](https://github.com/americanexpress/jest-image-snapshot#optional-configuration) can be passed in the `options` argument to `addMatchImageSnapshotCommand` and `cy.matchImageSnapshot()`. The local options in `cy.matchImageSnapshot()` will overwrite the default options set in `addMatchImageSnapshot`.
 
 For example, the default options we use in `<rootDir>/cypress/support/commands.js` are:
 


### PR DESCRIPTION
If `customDiffDir` is passed as an option, image diffs will be written to that directory with a folder structure that mirrors the screenshots and snapshots and without the `__diff_output__` folder as that will be redundant in this case.