### PR TITLE
Update to jest-image-snapshot@2.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "fs-extra": "^7.0.0",
-    "jest-image-snapshot": "2.4.3"
+    "jest-image-snapshot": "2.7.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -76,6 +76,7 @@ export function matchImageSnapshotPlugin({ path: screenshotPath }) {
 
   snapshotResults = diffImageToSnapshot({
     snapshotsDir,
+    diffDir,
     receivedImageBuffer,
     snapshotIdentifier,
     failureThreshold,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2482,9 +2482,9 @@ jest-haste-map@^23.2.0:
     micromatch "^3.1.10"
     sane "^2.0.0"
 
-jest-image-snapshot@2.4.3:
-  version "2.4.3"
-  resolved "https://registry.yarnpkg.com/jest-image-snapshot/-/jest-image-snapshot-2.4.3.tgz#68422dc0040a7855fa837cf015a1a3bb3d4c35db"
+jest-image-snapshot@2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/jest-image-snapshot/-/jest-image-snapshot-2.7.0.tgz#6e3b11a1d5895123c45ce034e0fd163fe49e6149"
   dependencies:
     chalk "^1.1.3"
     get-stdin "^5.0.1"


### PR DESCRIPTION
This update results in our tests with failing image diffs finishing in 7 seconds instead of 11-12 seconds.