### PR TITLE
Remove cache file on reporter end

### DIFF
--- a/src/reporter.js
+++ b/src/reporter.js
@@ -22,9 +22,9 @@ function reporter(runner) {
         );
         termImage(diffOutputPath, { fallback });
       });
-
-      fs.removeSync(cachePath);
     }
+
+    fs.removeSync(cachePath);
   });
 }
 


### PR DESCRIPTION
Since the cache file is always created, we always need to remove it.