### PR TITLE
Set cache path according to project root

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "fs-extra": "^7.0.1",
     "glob": "^7.1.3",
     "jest-image-snapshot": "2.7.0",
+    "pkg-dir": "^3.0.0",
     "term-img": "^4.0.0"
   },
   "devDependencies": {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -7,6 +7,7 @@
 
 import path from 'path';
 import fs from 'fs-extra';
+import pkgDir from 'pkg-dir';
 import { diffImageToSnapshot } from 'jest-image-snapshot/src/diff-snapshot';
 import { MATCH, RECORD } from './constants';
 
@@ -18,7 +19,7 @@ const dotSnap = '.snap.png';
 const dotDiff = '.diff.png';
 
 export const cachePath = path.join(
-  process.cwd(),
+  pkgDir.sync(process.cwd()),
   'cypress',
   '.snapshot-report'
 );


### PR DESCRIPTION
Previously we were assuming that `cypress run` was always run from the project root when it can actually be run from subdirectories.

[pkg-dir](https://www.npmjs.com/package/pkg-dir) finds the root `package.json` which I think should be sufficient for our use case.

Closes #65.