### PR TITLE
Add error message when image sizes are different

### DIFF
--- a/src/command.js
+++ b/src/command.js
@@ -36,13 +36,23 @@ export function matchImageSnapshotCommand(defaultOptions) {
           pass,
           added,
           updated,
+          diffSize,
+          imageDimensions,
           diffRatio,
           diffPixelCount,
           diffOutputPath,
         }) => {
           if (!pass && !added && !updated) {
-            const message = `Screenshot was ${diffRatio *
-              100}% different from saved snapshot with ${diffPixelCount} different pixels.\n  See diff for details: ${diffOutputPath}`;
+            const message = diffSize
+              ? `Image size (${imageDimensions.baselineWidth}x${
+                  imageDimensions.baselineHeight
+                }) different than saved snapshot size (${
+                  imageDimensions.receivedWidth
+                }x${
+                  imageDimensions.receivedHeight
+                }).\nSee diff for details: ${diffOutputPath}`
+              : `Image was ${diffRatio *
+                  100}% different from saved snapshot with ${diffPixelCount} different pixels.\nSee diff for details: ${diffOutputPath}`;
 
             if (failOnSnapshotDiff) {
               throw new Error(message);


### PR DESCRIPTION
When comparing images of different sizes, `diffRatio` and `diffPixelCount` are both 0 resulting in confusing error messages.  This PR adds a clearer error message for this scenario:
```
Error: Image size (1000x660) different than saved snapshot size (2000x1320).
See diff for details: /Users/jack/dev/github/palmerhq/cypress-image-snapshot/examples/cypress/snapshots/App.test.js/__diff_output__/App -- should render on desktop.diff.png
```

Closes #79.