### PR TITLE
Fix handling of windows paths

### DIFF
--- a/__tests__/plugin.test.js
+++ b/__tests__/plugin.test.js
@@ -7,8 +7,8 @@
 
 import { diffImageToSnapshot } from 'jest-image-snapshot/src/diff-snapshot';
 import {
-  matchImageSnapshotPlugin,
   matchImageSnapshotOptions,
+  matchImageSnapshotPlugin,
 } from '../src/plugin';
 
 jest.mock('jest-image-snapshot/src/diff-snapshot', () => ({
@@ -42,7 +42,7 @@ describe('plugin', () => {
       path: '/cypress/snapshots/path/to/__diff_output__/cheese.diff.png',
     });
     expect(diffImageToSnapshot).toHaveBeenCalledWith({
-      snapshotsDir: '/cypress/snapshots/path/to/',
+      snapshotsDir: '/cypress/snapshots/path/to',
       diffDir: '/cypress/snapshots/path/to/__diff_output__',
       updateSnapshot: true,
       receivedImageBuffer: 'cheese',

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -69,14 +69,11 @@ export function matchImageSnapshotPlugin({ path: screenshotPath }) {
   const receivedImageBuffer = fs.readFileSync(screenshotPath);
   fs.removeSync(screenshotPath);
 
-  const screenshotFileName = screenshotPath.slice(
-    screenshotPath.lastIndexOf(path.sep) + 1
+  const { dir: screenshotDir, name: snapshotIdentifier } = path.parse(
+    screenshotPath
   );
-  const screenshotDir = screenshotPath.replace(screenshotFileName, '');
-  const relativePath = screenshotDir.match(
-    new RegExp(`${screenshotsFolder}(.*)`)
-  )[1];
-  const snapshotIdentifier = screenshotFileName.replace('.png', '');
+
+  const relativePath = path.relative(screenshotsFolder, screenshotDir);
   const snapshotsDir = customSnapshotsDir
     ? path.join(process.cwd(), customSnapshotsDir, relativePath)
     : path.join(screenshotsFolder, '..', 'snapshots', relativePath);


### PR DESCRIPTION
This PR fixes an issue where the `\` in Window's paths was preventing a regex from matching correctly.  I opted to use Node's `path.parse` and `path.relative` methods which should handle any edge cases.

Closes #77.